### PR TITLE
Pass cloned objects into recursive _.deepExtend() calls

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,14 +31,14 @@ return function underscoreDeepExtend(obj) {
         if (!_.isArray(obj[prop]) || !_.isArray(source[prop])){
           throw new Error('Trying to combine an array with a non-array (' + prop + ')');
         } else {
-          obj[prop] = _.reject(_.deepExtend(obj[prop], source[prop]), function (item) { return _.isNull(item);});
+          obj[prop] = _.reject(_.deepExtend(_.clone(obj)[prop], source[prop]), function (item) { return _.isNull(item);});
         }
       }
       else if (_.isObject(obj[prop]) || _.isObject(source[prop])){
         if (!_.isObject(obj[prop]) || !_.isObject(source[prop])){
           throw new Error('Trying to combine an object with a non-object (' + prop + ')');
         } else {
-          obj[prop] = _.deepExtend(obj[prop], source[prop]);
+          obj[prop] = _.deepExtend(_.clone(obj)[prop], source[prop]);
         }
       } else {
         obj[prop] = source[prop];

--- a/index.js
+++ b/index.js
@@ -31,14 +31,14 @@ return function underscoreDeepExtend(obj) {
         if (!_.isArray(obj[prop]) || !_.isArray(source[prop])){
           throw new Error('Trying to combine an array with a non-array (' + prop + ')');
         } else {
-          obj[prop] = _.reject(_.deepExtend(_.clone(obj)[prop], source[prop]), function (item) { return _.isNull(item);});
+          obj[prop] = _.reject(_.deepExtend(_.clone(obj[prop]), source[prop]), function (item) { return _.isNull(item);});
         }
       }
       else if (_.isObject(obj[prop]) || _.isObject(source[prop])){
         if (!_.isObject(obj[prop]) || !_.isObject(source[prop])){
           throw new Error('Trying to combine an object with a non-object (' + prop + ')');
         } else {
-          obj[prop] = _.deepExtend(_.clone(obj)[prop], source[prop]);
+          obj[prop] = _.deepExtend(_.clone(obj[prop]), source[prop]);
         }
       } else {
         obj[prop] = source[prop];


### PR DESCRIPTION
Related to Issue #10, as well as to this comment on the [gist](https://gist.github.com/kurtmilam/1868955#comment-1356616).

I was passing `obj[prop]` straight into recursive `_.deepExtend()` calls (for properties that were objects or arrays). This resulted in the unwanted modification of intermediate objects and arrays. Passing in `_.clone(obj[prop])` takes care of the problem.

It seems the erratic behavior was introduced along with the fix for Issue #6.